### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/Dinoshauer/ImportConfig.svg?branch=master)](https://travis-ci.org/Dinoshauer/ImportConfig)
 [![Coverage Status](https://coveralls.io/repos/Dinoshauer/ImportConfig/badge.png)](https://coveralls.io/r/Dinoshauer/ImportConfig)
 [![Documentation Status](https://readthedocs.org/projects/importconfig/badge/?version=latest)](https://readthedocs.org/projects/importconfig/?badge=latest)
-[![Latest Version](https://pypip.in/version/ImportConfig/badge.svg?style=flat)](https://pypi.python.org/pypi/ImportConfig/)
+[![Latest Version](https://img.shields.io/pypi/v/ImportConfig.svg?style=flat)](https://pypi.python.org/pypi/ImportConfig/)
 
 
 ImportConfig


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20importconfig))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `importconfig`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.